### PR TITLE
[UI Performance] State hoisting and lifecycle-aware collection                                                                                                                                                  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ local.properties
 # Log Files
 *.log
 
+# oh-my-claude
+.omx/
+
+# Benchmark results (large trace files)
+benchmark-results/
+
 # Android Studio Navigation editor temp files
 .navigation/
 

--- a/benchmark/src/main/java/com/example/benchmark/BottomSheetBenchmarkTest.kt
+++ b/benchmark/src/main/java/com/example/benchmark/BottomSheetBenchmarkTest.kt
@@ -11,7 +11,6 @@ import androidx.test.filters.LargeTest
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
-import androidx.tracing.Trace
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,7 +21,6 @@ class BottomSheetBenchmarkTest {
 
     @get:Rule
     val benchmarkRule = MacrobenchmarkRule()
-
 
     @OptIn(ExperimentalMetricApi::class)
     @Test
@@ -36,45 +34,82 @@ class BottomSheetBenchmarkTest {
             measureBlock = {
                 startActivityAndWait()
 
-
-                if (device.wait(Until.hasObject(By.desc("NationalPlaylistItem")), 3000)) {
-                    val nationalPlaylistItem =
-                        device.findObject(UiSelector().description("NationalPlaylistItem"))
-                    nationalPlaylistItem.click()
+                if (device.wait(Until.hasObject(By.desc("NationalPlaylistItem")), 10000)) {
+                    device.findObject(UiSelector().description("NationalPlaylistItem")).click()
                 } else {
-                    throw AssertionError("NationalPlaylistItem not found within 3 seconds!")
+                    throw AssertionError("NationalPlaylistItem not found within 10s")
                 }
 
-                if (device.wait(Until.hasObject(By.desc("CommonVideoItem")), 3000)) {
-                    val commonVideoItem =
-                        device.findObject(UiSelector().description("CommonVideoItem"))
-                    commonVideoItem.click()
+                if (device.wait(Until.hasObject(By.desc("CommonVideoItem")), 10000)) {
+                    device.findObject(UiSelector().description("CommonVideoItem")).click()
                 } else {
-                    throw AssertionError("CommonVideoItem not found within 3 seconds!")
+                    throw AssertionError("CommonVideoItem not found within 10s")
                 }
 
-                if (!device.wait(Until.hasObject(By.desc("PlayerThumbnailView")), 3000)) {
-                    throw AssertionError("PlayerThumbnailView not found within 5 seconds!")
+                if (!device.wait(Until.hasObject(By.desc("PlayerThumbnailView")), 10000)) {
+                    throw AssertionError("PlayerThumbnailView not found within 10s")
                 }
 
                 Thread.sleep(3000)
+            }
+        )
+    }
 
-//                val playerThumbnailView = device.findObject(UiSelector().description("PlayerThumbnailView"))
-//                val rect = playerThumbnailView.bounds
-//                val centerX = rect.centerX()
-//                val centerY = rect.centerY()
-//
-//                device.swipe(centerX, centerY + 300, centerX, centerY - 300, 10)
-//
-//                device.wait(Until.hasObject(By.desc("BottomPlayerCloseButton")), 3000)
-//
-//                val updatedPlayerThumbnailView = device.findObject(UiSelector().description("PlayerThumbnailView"))
-//                val updatedRect = updatedPlayerThumbnailView.bounds
-//                val updatedCenterX = updatedRect.centerX()
-//                val updatedCenterY = updatedRect.centerY()
-//
-//                device.swipe(updatedCenterX, updatedCenterY - 300, updatedCenterX, updatedCenterY + 300, 10)
+    @OptIn(ExperimentalMetricApi::class)
+    @Test
+    fun bottomSheetDragPerformance() {
+        benchmarkRule.measureRepeated(
+            packageName = "com.example.transpose",
+            metrics = listOf(
+                FrameTimingMetric(),
+                TraceSectionMetric("PlayerBottomSheet", TraceSectionMetric.Mode.Sum),
+                TraceSectionMetric("MainPlayerLayout", TraceSectionMetric.Mode.Sum),
+                TraceSectionMetric("PlayerThumbnailView", TraceSectionMetric.Mode.Sum)
+            ),
+            iterations = 5,
+            startupMode = StartupMode.WARM,
+            setupBlock = {
+                startActivityAndWait()
 
+                // 1. 홈 화면 로드 (네트워크 의존, 넉넉하게 15초)
+                if (!device.wait(Until.hasObject(By.desc("NationalPlaylistItem")), 15000)) {
+                    throw AssertionError(
+                        "NationalPlaylistItem not found within 15s - check network"
+                    )
+                }
+                device.findObject(UiSelector().description("NationalPlaylistItem")).click()
+
+                // 2. 플레이리스트 영상 목록 로드
+                if (!device.wait(Until.hasObject(By.desc("CommonVideoItem")), 15000)) {
+                    throw AssertionError(
+                        "CommonVideoItem not found within 15s - playlist may not have loaded"
+                    )
+                }
+                device.findObject(UiSelector().description("CommonVideoItem")).click()
+
+                // 3. 플레이어 표시 대기 - 실패해도 진행 (bottomSheet는 올라와 있을 수 있음)
+                device.wait(Until.hasObject(By.desc("PlayerThumbnailView")), 15000)
+
+                // 영상 로딩 및 재생 안정화 대기
+                Thread.sleep(5000)
+            },
+            measureBlock = {
+                val screenWidth = device.displayWidth
+                val screenHeight = device.displayHeight
+                val centerX = screenWidth / 2
+
+                val bottomY = (screenHeight * 0.85).toInt()
+                val topY = (screenHeight * 0.15).toInt()
+
+                repeat(3) {
+                    // expand
+                    device.swipe(centerX, bottomY, centerX, topY, 15)
+                    Thread.sleep(800)
+
+                    // collapse
+                    device.swipe(centerX, topY, centerX, bottomY, 15)
+                    Thread.sleep(800)
+                }
             }
         )
     }

--- a/build-logic/convention/src/main/java/com/example/convention/AndroidCompose.kt
+++ b/build-logic/convention/src/main/java/com/example/convention/AndroidCompose.kt
@@ -29,4 +29,29 @@ internal fun Project.configureAndroidCompose(
             add("debugImplementation", libs.findLibrary("androidx.ui.tooling.preview").get())
         }
     }
+
+    // Stability configuration for Compose compiler
+    val stabilityConfigFile = project.rootProject.file("compose-stability.conf")
+    if (stabilityConfigFile.exists()) {
+        project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+            compilerOptions {
+                freeCompilerArgs.addAll(
+                    "-P", "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=${stabilityConfigFile.absolutePath}"
+                )
+            }
+        }
+    }
+
+    // Compose Compiler Metrics: run with -Ptranspose.enableComposeCompilerReports=true
+    if (project.findProperty("transpose.enableComposeCompilerReports") == "true") {
+        val metricsDir = project.layout.buildDirectory.dir("compose_metrics").get().asFile
+        project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+            compilerOptions {
+                freeCompilerArgs.addAll(
+                    "-P", "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=${metricsDir.absolutePath}",
+                    "-P", "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=${metricsDir.absolutePath}"
+                )
+            }
+        }
+    }
 }

--- a/compose-stability.conf
+++ b/compose-stability.conf
@@ -1,0 +1,16 @@
+// Compose Compiler Stability Configuration
+// Types listed here are treated as stable by the Compose compiler.
+
+// Kotlin collections from StateFlow are always new instances (never mutated in place)
+kotlin.collections.List
+kotlin.collections.Map
+kotlin.collections.Set
+
+// Android framework types that are effectively immutable
+android.net.Uri
+
+// NewPipe extractor types used in VideoDetail
+org.schabi.newpipe.extractor.stream.VideoStream
+org.schabi.newpipe.extractor.stream.AudioStream
+org.schabi.newpipe.extractor.InfoItem.InfoType
+org.schabi.newpipe.extractor.playlist.PlaylistInfo.PlaylistType

--- a/core/ui/src/main/java/com/example/ui/components/dialog/AddItemToPlaylistDialog.kt
+++ b/core/ui/src/main/java/com/example/ui/components/dialog/AddItemToPlaylistDialog.kt
@@ -21,7 +21,10 @@ fun AddItemToPlaylistDialog(
         title = { Text(stringResource(id = R.string.video_pop_up_menu_add_playlist_text)) },
         text = {
             LazyColumn {
-                items(playlists.size) { index ->
+                items(
+                    count = playlists.size,
+                    key = { playlists[it].playlistId }
+                ) { index ->
                     val item = playlists[index]
                     MyPlaylistItem(
                         title = item.name,

--- a/core/ui/src/main/java/com/example/ui/components/scrollbar/EndlessLazyColumn.kt
+++ b/core/ui/src/main/java/com/example/ui/components/scrollbar/EndlessLazyColumn.kt
@@ -42,7 +42,7 @@ fun <H, T> EndlessLazyColumn(
                 headerContent(headerData)
             }
         }
-        items(items.size){ index ->
+        items(count = items.size, key = { itemKey(items[it]) }){ index ->
             val item = items[index]
             itemContent(index, item)
             if (index == items.size - 1 && hasMoreItems)

--- a/core/ui/src/main/java/com/example/ui/screen/channel/ChannelScreen.kt
+++ b/core/ui/src/main/java/com/example/ui/screen/channel/ChannelScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -59,13 +59,13 @@ fun ChannelScreen(
     bottomSheetState: SheetState,
     onNavigateToPlaylistInfoScreen: (String) -> Unit
 ) {
-    val channelDetailData by channelViewModel.channelDetail.collectAsState()
-    val isChannelDetailLoading by channelViewModel.isChannelDetailDataLoading.collectAsState()
+    val channelDetailData by channelViewModel.channelDetail.collectAsStateWithLifecycle()
+    val isChannelDetailLoading by channelViewModel.isChannelDetailDataLoading.collectAsStateWithLifecycle()
 
     // 각 탭의 상태 가져오기
-    val videosState by channelViewModel.channelTabVideos.collectAsState()
-    val shortsState by channelViewModel.channelTabShorts.collectAsState()
-    val playlistsState by channelViewModel.channelTabPlaylists.collectAsState()
+    val videosState by channelViewModel.channelTabVideos.collectAsStateWithLifecycle()
+    val shortsState by channelViewModel.channelTabShorts.collectAsStateWithLifecycle()
+    val playlistsState by channelViewModel.channelTabPlaylists.collectAsStateWithLifecycle()
 
     val videosScrollState = rememberSaveable(saver = LazyListState.Saver) {
         LazyListState()

--- a/core/ui/src/main/java/com/example/ui/screen/playlist_info/PlaylistInfoScreen.kt
+++ b/core/ui/src/main/java/com/example/ui/screen/playlist_info/PlaylistInfoScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -35,8 +34,8 @@ fun PlaylistInfoScreen(
     playlistId: String?,
 ) {
 
-    val playlistInfo by playlistInfoViewModel.currentPlaylistInfo.collectAsState()
-    val playlistItemsState by playlistInfoViewModel.playlistItemsState.collectAsState()
+    val playlistInfo by playlistInfoViewModel.currentPlaylistInfo.collectAsStateWithLifecycle()
+    val playlistItemsState by playlistInfoViewModel.playlistItemsState.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
     var isShowingPlaylistDialog by remember {

--- a/core/ui/src/main/java/com/example/ui/screen/search_result/SearchResultScreen.kt
+++ b/core/ui/src/main/java/com/example/ui/screen/search_result/SearchResultScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,7 +36,7 @@ fun SearchResultScreen(
     navigateToBack: () -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
-    val searchResultsState by searchResultViewModel.searchResultsState.collectAsState()
+    val searchResultsState by searchResultViewModel.searchResultsState.collectAsStateWithLifecycle()
     val context = LocalContext.current
     var isShowingPlaylistDialog by remember {
         mutableStateOf(false)
@@ -45,7 +45,7 @@ fun SearchResultScreen(
         mutableStateOf(null as SearchResult.VideoResult?)
     }
 
-    val myPlaylists by searchResultViewModel.myPlaylists.collectAsState()
+    val myPlaylists by searchResultViewModel.myPlaylists.collectAsStateWithLifecycle()
 
     BackHandler(
         enabled = bottomSheetState.currentValue == SheetValue.Expanded

--- a/core/ui/src/main/java/com/example/ui/screen/settings/SettingsScreen.kt
+++ b/core/ui/src/main/java/com/example/ui/screen/settings/SettingsScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -54,7 +54,7 @@ fun SettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
-    val currentQuality by viewModel.videoQuality.collectAsState()
+    val currentQuality by viewModel.videoQuality.collectAsStateWithLifecycle()
     var showQualityDialog by remember { mutableStateOf(false) }
 
     Scaffold(

--- a/feature/convert/src/main/java/com/example/convert/audio_edit/components/pitch/PitchSection.kt
+++ b/feature/convert/src/main/java/com/example/convert/audio_edit/components/pitch/PitchSection.kt
@@ -1,7 +1,7 @@
 package com.example.convert.audio_edit.components.pitch
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import com.example.convert.audio_edit.ConvertAudioEditViewModel
 import com.example.convert.audio_edit.components.SliderSection
@@ -11,7 +11,7 @@ import java.util.Locale
 fun PitchSection(
     convertAudioEditViewModel: ConvertAudioEditViewModel
 ) {
-    val pitchValue by convertAudioEditViewModel.pitchValue.collectAsState()
+    val pitchValue by convertAudioEditViewModel.pitchValue.collectAsStateWithLifecycle()
 
     val actualValue = (pitchValue * 0.1) - 10.0
 

--- a/feature/convert/src/main/java/com/example/convert/audio_edit/components/signalsmith/ChorusSection.kt
+++ b/feature/convert/src/main/java/com/example/convert/audio_edit/components/signalsmith/ChorusSection.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -34,11 +34,11 @@ fun ChorusSection(
     convertAudioEditViewModel: ConvertAudioEditViewModel,
     onExpandChanged: (Boolean) -> Unit = {}
 ) {
-    val isEnabled by convertAudioEditViewModel.isChorusEnabled.collectAsState()
-    val mix by convertAudioEditViewModel.chorusMix.collectAsState()
-    val depthMs by convertAudioEditViewModel.chorusDepthMs.collectAsState()
-    val detune by convertAudioEditViewModel.chorusDetune.collectAsState()
-    val stereo by convertAudioEditViewModel.chorusStereo.collectAsState()
+    val isEnabled by convertAudioEditViewModel.isChorusEnabled.collectAsStateWithLifecycle()
+    val mix by convertAudioEditViewModel.chorusMix.collectAsStateWithLifecycle()
+    val depthMs by convertAudioEditViewModel.chorusDepthMs.collectAsStateWithLifecycle()
+    val detune by convertAudioEditViewModel.chorusDetune.collectAsStateWithLifecycle()
+    val stereo by convertAudioEditViewModel.chorusStereo.collectAsStateWithLifecycle()
     var isExpanded by rememberSaveable { mutableStateOf(false) }
     var selectedPresetIndex by rememberSaveable { mutableIntStateOf(-1) }
 

--- a/feature/convert/src/main/java/com/example/convert/audio_edit/components/signalsmith/CompressorSection.kt
+++ b/feature/convert/src/main/java/com/example/convert/audio_edit/components/signalsmith/CompressorSection.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -34,12 +34,12 @@ fun CompressorSection(
     convertAudioEditViewModel: ConvertAudioEditViewModel,
     onExpandChanged: (Boolean) -> Unit = {}
 ) {
-    val isEnabled by convertAudioEditViewModel.isCompressorEnabled.collectAsState()
-    val thresholdDb by convertAudioEditViewModel.compThresholdDb.collectAsState()
-    val ratio by convertAudioEditViewModel.compRatio.collectAsState()
-    val attackMs by convertAudioEditViewModel.compAttackMs.collectAsState()
-    val releaseMs by convertAudioEditViewModel.compReleaseMs.collectAsState()
-    val makeupGainDb by convertAudioEditViewModel.compMakeupGainDb.collectAsState()
+    val isEnabled by convertAudioEditViewModel.isCompressorEnabled.collectAsStateWithLifecycle()
+    val thresholdDb by convertAudioEditViewModel.compThresholdDb.collectAsStateWithLifecycle()
+    val ratio by convertAudioEditViewModel.compRatio.collectAsStateWithLifecycle()
+    val attackMs by convertAudioEditViewModel.compAttackMs.collectAsStateWithLifecycle()
+    val releaseMs by convertAudioEditViewModel.compReleaseMs.collectAsStateWithLifecycle()
+    val makeupGainDb by convertAudioEditViewModel.compMakeupGainDb.collectAsStateWithLifecycle()
     var isExpanded by rememberSaveable { mutableStateOf(false) }
     var selectedPresetIndex by rememberSaveable { mutableIntStateOf(-1) }
 

--- a/feature/convert/src/main/java/com/example/convert/audio_edit/components/signalsmith/EqSection.kt
+++ b/feature/convert/src/main/java/com/example/convert/audio_edit/components/signalsmith/EqSection.kt
@@ -17,7 +17,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -43,13 +43,13 @@ fun EqSection(
     convertAudioEditViewModel: ConvertAudioEditViewModel,
     onExpandChanged: (Boolean) -> Unit = {}
 ) {
-    val isEnabled by convertAudioEditViewModel.isEqEnabled.collectAsState()
-    val currentPreset by convertAudioEditViewModel.eqPreset.collectAsState()
-    val band1Gain by convertAudioEditViewModel.eqBand1Gain.collectAsState()
-    val band2Gain by convertAudioEditViewModel.eqBand2Gain.collectAsState()
-    val band3Gain by convertAudioEditViewModel.eqBand3Gain.collectAsState()
-    val band4Gain by convertAudioEditViewModel.eqBand4Gain.collectAsState()
-    val band5Gain by convertAudioEditViewModel.eqBand5Gain.collectAsState()
+    val isEnabled by convertAudioEditViewModel.isEqEnabled.collectAsStateWithLifecycle()
+    val currentPreset by convertAudioEditViewModel.eqPreset.collectAsStateWithLifecycle()
+    val band1Gain by convertAudioEditViewModel.eqBand1Gain.collectAsStateWithLifecycle()
+    val band2Gain by convertAudioEditViewModel.eqBand2Gain.collectAsStateWithLifecycle()
+    val band3Gain by convertAudioEditViewModel.eqBand3Gain.collectAsStateWithLifecycle()
+    val band4Gain by convertAudioEditViewModel.eqBand4Gain.collectAsStateWithLifecycle()
+    val band5Gain by convertAudioEditViewModel.eqBand5Gain.collectAsStateWithLifecycle()
     var isExpanded by rememberSaveable { mutableStateOf(false) }
 
     val isKorean = LocalConfiguration.current.locales[0].language == "ko"

--- a/feature/convert/src/main/java/com/example/convert/audio_edit/components/signalsmith/LimiterSection.kt
+++ b/feature/convert/src/main/java/com/example/convert/audio_edit/components/signalsmith/LimiterSection.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -34,11 +34,11 @@ fun LimiterSection(
     convertAudioEditViewModel: ConvertAudioEditViewModel,
     onExpandChanged: (Boolean) -> Unit = {}
 ) {
-    val isEnabled by convertAudioEditViewModel.isLimiterEnabled.collectAsState()
-    val inputGainDb by convertAudioEditViewModel.limiterInputGainDb.collectAsState()
-    val limitDb by convertAudioEditViewModel.limiterLimitDb.collectAsState()
-    val attackMs by convertAudioEditViewModel.limiterAttackMs.collectAsState()
-    val releaseMs by convertAudioEditViewModel.limiterReleaseMs.collectAsState()
+    val isEnabled by convertAudioEditViewModel.isLimiterEnabled.collectAsStateWithLifecycle()
+    val inputGainDb by convertAudioEditViewModel.limiterInputGainDb.collectAsStateWithLifecycle()
+    val limitDb by convertAudioEditViewModel.limiterLimitDb.collectAsStateWithLifecycle()
+    val attackMs by convertAudioEditViewModel.limiterAttackMs.collectAsStateWithLifecycle()
+    val releaseMs by convertAudioEditViewModel.limiterReleaseMs.collectAsStateWithLifecycle()
     var isExpanded by rememberSaveable { mutableStateOf(false) }
     var selectedPresetIndex by rememberSaveable { mutableIntStateOf(-1) }
 

--- a/feature/convert/src/main/java/com/example/convert/audio_edit/components/signalsmith/SignalsmithReverbSection.kt
+++ b/feature/convert/src/main/java/com/example/convert/audio_edit/components/signalsmith/SignalsmithReverbSection.kt
@@ -17,7 +17,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -44,12 +44,12 @@ fun SignalsmithReverbSection(
     convertAudioEditViewModel: ConvertAudioEditViewModel,
     onExpandChanged: (Boolean) -> Unit = {}
 ) {
-    val isEnabled by convertAudioEditViewModel.isSignalsmithReverbEnabled.collectAsState()
-    val currentPreset by convertAudioEditViewModel.signalsmithReverbPreset.collectAsState()
-    val dry by convertAudioEditViewModel.signalsmithReverbDry.collectAsState()
-    val wet by convertAudioEditViewModel.signalsmithReverbWet.collectAsState()
-    val roomMs by convertAudioEditViewModel.signalsmithReverbRoomMs.collectAsState()
-    val decaySec by convertAudioEditViewModel.signalsmithReverbDecaySec.collectAsState()
+    val isEnabled by convertAudioEditViewModel.isSignalsmithReverbEnabled.collectAsStateWithLifecycle()
+    val currentPreset by convertAudioEditViewModel.signalsmithReverbPreset.collectAsStateWithLifecycle()
+    val dry by convertAudioEditViewModel.signalsmithReverbDry.collectAsStateWithLifecycle()
+    val wet by convertAudioEditViewModel.signalsmithReverbWet.collectAsStateWithLifecycle()
+    val roomMs by convertAudioEditViewModel.signalsmithReverbRoomMs.collectAsStateWithLifecycle()
+    val decaySec by convertAudioEditViewModel.signalsmithReverbDecaySec.collectAsStateWithLifecycle()
     var isExpanded by rememberSaveable { mutableStateOf(false) }
 
     val isKorean = LocalConfiguration.current.locales[0].language == "ko"

--- a/feature/convert/src/main/java/com/example/convert/audio_edit/components/signalsmith/StereoWidenerSection.kt
+++ b/feature/convert/src/main/java/com/example/convert/audio_edit/components/signalsmith/StereoWidenerSection.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -34,8 +34,8 @@ fun StereoWidenerSection(
     convertAudioEditViewModel: ConvertAudioEditViewModel,
     onExpandChanged: (Boolean) -> Unit = {}
 ) {
-    val isEnabled by convertAudioEditViewModel.isStereoWidenerEnabled.collectAsState()
-    val width by convertAudioEditViewModel.stereoWidenerWidth.collectAsState()
+    val isEnabled by convertAudioEditViewModel.isStereoWidenerEnabled.collectAsStateWithLifecycle()
+    val width by convertAudioEditViewModel.stereoWidenerWidth.collectAsStateWithLifecycle()
     var isExpanded by rememberSaveable { mutableStateOf(false) }
     var selectedPresetIndex by rememberSaveable { mutableIntStateOf(-1) }
 

--- a/feature/convert/src/main/java/com/example/convert/audio_edit/components/signalsmith/VirtualizerSection.kt
+++ b/feature/convert/src/main/java/com/example/convert/audio_edit/components/signalsmith/VirtualizerSection.kt
@@ -15,7 +15,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -52,9 +52,9 @@ fun SignalsmithVirtualizerSection(
     convertAudioEditViewModel: ConvertAudioEditViewModel,
     onExpandChanged: (Boolean) -> Unit = {}
 ) {
-    val isEnabled by convertAudioEditViewModel.isHrtfEnabled.collectAsState()
-    val intensity by convertAudioEditViewModel.hrtfIntensity.collectAsState()
-    val azimuth by convertAudioEditViewModel.hrtfAzimuth.collectAsState()
+    val isEnabled by convertAudioEditViewModel.isHrtfEnabled.collectAsStateWithLifecycle()
+    val intensity by convertAudioEditViewModel.hrtfIntensity.collectAsStateWithLifecycle()
+    val azimuth by convertAudioEditViewModel.hrtfAzimuth.collectAsStateWithLifecycle()
     var isExpanded by rememberSaveable { mutableStateOf(false) }
 
     Column(

--- a/feature/convert/src/main/java/com/example/convert/audio_edit/components/tempo/TempoSection.kt
+++ b/feature/convert/src/main/java/com/example/convert/audio_edit/components/tempo/TempoSection.kt
@@ -1,7 +1,7 @@
 package com.example.convert.audio_edit.components.tempo
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import com.example.convert.audio_edit.ConvertAudioEditViewModel
 import com.example.convert.audio_edit.components.SliderSection
@@ -9,7 +9,7 @@ import java.util.Locale
 
 @Composable
 fun TempoSection(convertAudioEditViewModel: ConvertAudioEditViewModel) {
-    val tempoValue by convertAudioEditViewModel.tempoValue.collectAsState()
+    val tempoValue by convertAudioEditViewModel.tempoValue.collectAsStateWithLifecycle()
     val actualValue = (tempoValue * 0.1) - 10.0
 
     val displayText = if (actualValue >= 0) {

--- a/feature/home/src/main/java/com/example/home/home_playlist/HomePlaylistScreen.kt
+++ b/feature/home/src/main/java/com/example/home/home_playlist/HomePlaylistScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -46,9 +46,9 @@ fun HomePlaylistScreen(
     modifier: Modifier = Modifier,
     navigateToBack: () -> Unit
 ) {
-    val nationalPlaylistState by homePlaylistViewModel.nationalPlaylistDataState.collectAsState()
-    val recommendedPlaylistState by homePlaylistViewModel.recommendedPlaylistDataState.collectAsState()
-    val typedPlaylistState by homePlaylistViewModel.typedPlaylistDataState.collectAsState()
+    val nationalPlaylistState by homePlaylistViewModel.nationalPlaylistDataState.collectAsStateWithLifecycle()
+    val recommendedPlaylistState by homePlaylistViewModel.recommendedPlaylistDataState.collectAsStateWithLifecycle()
+    val typedPlaylistState by homePlaylistViewModel.typedPlaylistDataState.collectAsStateWithLifecycle()
     val coroutineScope = rememberCoroutineScope()
 
     BackHandler(

--- a/feature/library/src/main/java/com/example/library/my_local_item/LibraryMyLocalItemScreen.kt
+++ b/feature/library/src/main/java/com/example/library/my_local_item/LibraryMyLocalItemScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -37,13 +37,13 @@ fun LibraryMyLocalItemScreen(
     isLocalSearchActive: Boolean = false,
     onCloseLocalSearch: () -> Unit = {}
 ) {
-    val recoverableDeleteException by libraryMyLocalItemViewModel.recoverableDeleteEvent.collectAsState()
+    val recoverableDeleteException by libraryMyLocalItemViewModel.recoverableDeleteEvent.collectAsStateWithLifecycle()
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
 
     var isShowingPlaylistDialog by remember { mutableStateOf(false) }
     var selectedLocalFile by remember { mutableStateOf<LocalFileData?>(null) }
-    val myPlaylists by libraryMyLocalItemViewModel.myPlaylists.collectAsState()
+    val myPlaylists by libraryMyLocalItemViewModel.myPlaylists.collectAsStateWithLifecycle()
 
     // "권한 다이얼로그"를 띄우는 런처
     val launcher = rememberLauncherForActivityResult(
@@ -69,8 +69,8 @@ fun LibraryMyLocalItemScreen(
             )
         }
     }
-    val audioFiles by libraryMyLocalItemViewModel.audioFiles.collectAsState()
-    val videoFiles by libraryMyLocalItemViewModel.videoFiles.collectAsState()
+    val audioFiles by libraryMyLocalItemViewModel.audioFiles.collectAsStateWithLifecycle()
+    val videoFiles by libraryMyLocalItemViewModel.videoFiles.collectAsStateWithLifecycle()
 
     val filteredAudioFiles = remember(audioFiles, localSearchQuery) {
         if (localSearchQuery.isBlank()) audioFiles
@@ -108,7 +108,10 @@ fun LibraryMyLocalItemScreen(
         when (type) {
             "audio" -> {
                 LazyColumn {
-                    items(filteredAudioFiles.size) { index ->
+                    items(
+                        count = filteredAudioFiles.size,
+                        key = { filteredAudioFiles[it].id }
+                    ) { index ->
                         val item = filteredAudioFiles[index]
                         LocalFileDataItem(
                             item = item,
@@ -133,7 +136,10 @@ fun LibraryMyLocalItemScreen(
 
             "video" -> {
                 LazyColumn {
-                    items(filteredVideoFiles.size) { index ->
+                    items(
+                        count = filteredVideoFiles.size,
+                        key = { filteredVideoFiles[it].id }
+                    ) { index ->
                         val item = filteredVideoFiles[index]
                         LocalFileDataItem(
                             item = item,

--- a/feature/library/src/main/java/com/example/library/my_playlist_item/LibraryMyPlaylistItemScreen.kt
+++ b/feature/library/src/main/java/com/example/library/my_playlist_item/LibraryMyPlaylistItemScreen.kt
@@ -56,7 +56,10 @@ fun LibraryMyPlaylistItemScreen(
                 LazyColumn(
                     modifier = Modifier.fillMaxSize()
                 ) {
-                    items(items.size) { index ->
+                    items(
+                        count = items.size,
+                        key = { items[it].id }
+                    ) { index ->
                         val item = items[index]
                         PlaylistItem(
                             item = item,

--- a/feature/main/src/main/java/com/example/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/example/main/MainScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -72,11 +72,13 @@ fun MainScreen(
 
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
-    val updateDialogState by mainViewModel.updateDialogState.collectAsState()
-    val localSearchQuery by mainViewModel.localSearchQuery.collectAsState()
-    val isLocalSearchActive by mainViewModel.isLocalSearchActive.collectAsState()
+    val updateDialogState by mainViewModel.updateDialogState.collectAsStateWithLifecycle()
+    val localSearchQuery by mainViewModel.localSearchQuery.collectAsStateWithLifecycle()
+    val isLocalSearchActive by mainViewModel.isLocalSearchActive.collectAsStateWithLifecycle()
+    val searchQuery by mainViewModel.searchQuery.collectAsStateWithLifecycle()
+    val suggestionKeywords by mainViewModel.suggestionKeywords.collectAsStateWithLifecycle()
 
-    val permissionGranted by mainViewModel.permissionGranted.collectAsState()
+    val permissionGranted by mainViewModel.permissionGranted.collectAsStateWithLifecycle()
 
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestMultiplePermissions()
@@ -216,11 +218,20 @@ fun MainScreen(
             }
     }
 
-    val blendRatio = bottomSheetOffset.coerceIn(0f, 1f)
-    val statusBarColor = blendColors(AppColors.StatusBarBackground, AppColors.CharcoalGray, blendRatio)
-    val navigationBarColor = blendColors(AppColors.BlueBackground, AppColors.CharcoalGray, blendRatio)
+    val statusBarColor by remember {
+        derivedStateOf {
+            val ratio = bottomSheetOffset.coerceIn(0f, 1f)
+            blendColors(AppColors.StatusBarBackground, AppColors.CharcoalGray, ratio)
+        }
+    }
+    val navigationBarColor by remember {
+        derivedStateOf {
+            val ratio = bottomSheetOffset.coerceIn(0f, 1f)
+            blendColors(AppColors.BlueBackground, AppColors.CharcoalGray, ratio)
+        }
+    }
 
-    SideEffect {
+    LaunchedEffect(statusBarColor, navigationBarColor) {
         systemUiController.setStatusBarColor(color = statusBarColor)
         systemUiController.setNavigationBarColor(color = navigationBarColor)
     }
@@ -291,13 +302,20 @@ fun MainScreen(
                         activeNavController.navigate(searchRouteFor(selectedTab, it))
                         searchBarState = SearchBarState.CLOSED
                     },
-                    mainViewModel = mainViewModel,
                     searchBarState = searchBarState,
                     updateSearchBarState = {
                         searchBarState = it
                     },
                     scrollBehavior = scrollBehavior,
                     isOnLocalFilesScreen = isOnLocalFilesScreen,
+                    isLocalSearchActive = isLocalSearchActive,
+                    localSearchQuery = localSearchQuery,
+                    searchQuery = searchQuery,
+                    suggestionKeywords = suggestionKeywords,
+                    onUpdateLocalSearchQuery = mainViewModel::updateLocalSearchQuery,
+                    onSetLocalSearchActive = mainViewModel::setLocalSearchActive,
+                    onUpdateSearchQuery = mainViewModel::updateSearchQuery,
+                    onClearSearchQuery = mainViewModel::clearSearchQuery,
                 )
             },
             mainViewModel = mainViewModel,
@@ -309,6 +327,7 @@ fun MainScreen(
                 activeNavController.navigate(channelRouteFor(selectedTab, channelId))
             },
             isLocalSearchActive = isLocalSearchActive,
+            onStopPlayback = mainViewModel::stopPlayback,
             ) { playerBottomSheetScaffoldPadding ->
             val miniPlayerHeightPx = with(density) { GraphicsLayerConstants.PEEK_HEIGHT.roundToPx() }
             val bottomNavHeightPx = with(density) { 56.dp.roundToPx() }

--- a/feature/main/src/main/java/com/example/main/components/appbar/MainAppBar.kt
+++ b/feature/main/src/main/java/com/example/main/components/appbar/MainAppBar.kt
@@ -33,7 +33,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -45,8 +44,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.example.main.MainViewModel
 import com.example.main.R
 import com.example.ui.components.items.SearchSuggestionItem
 import com.example.util.ToastUtil
@@ -58,30 +55,38 @@ import com.example.util.constants.AppColors
 fun MainAppBar(
     onSettingClicked: () -> Unit,
     onSearchClicked: (String) -> Unit,
-    mainViewModel: MainViewModel,
     searchBarState: SearchBarState,
     updateSearchBarState: (SearchBarState) -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
     isOnLocalFilesScreen: Boolean = false,
+    isLocalSearchActive: Boolean,
+    localSearchQuery: String,
+    searchQuery: String,
+    suggestionKeywords: List<String>,
+    onUpdateLocalSearchQuery: (String) -> Unit,
+    onSetLocalSearchActive: (Boolean) -> Unit,
+    onUpdateSearchQuery: (String) -> Unit,
+    onClearSearchQuery: () -> Unit,
 ) {
 
     val focusRequester = remember { FocusRequester() }
-    val isLocalSearchActive by mainViewModel.isLocalSearchActive.collectAsStateWithLifecycle()
-    val localSearchQuery by mainViewModel.localSearchQuery.collectAsStateWithLifecycle()
 
     Box {
         when {
             isLocalSearchActive && isOnLocalFilesScreen -> {
                 LocalSearchAppBar(
                     query = localSearchQuery,
-                    onQueryChange = mainViewModel::updateLocalSearchQuery,
-                    onClose = { mainViewModel.setLocalSearchActive(false) },
+                    onQueryChange = onUpdateLocalSearchQuery,
+                    onClose = { onSetLocalSearchActive(false) },
                     focusRequester = focusRequester
                 )
             }
             searchBarState == SearchBarState.OPENED -> {
                 CustomSearchAppBar(
-                    mainViewModel = mainViewModel,
+                    searchQuery = searchQuery,
+                    suggestionKeywords = suggestionKeywords,
+                    onUpdateSearchQuery = onUpdateSearchQuery,
+                    onClearSearchQuery = onClearSearchQuery,
                     updateSearchBarState = updateSearchBarState,
                     onSearchClicked = { onSearchClicked(it) },
                     focusRequester = focusRequester,
@@ -91,15 +96,13 @@ fun MainAppBar(
                 DefaultAppBar(
                     onSettingClicked = { onSettingClicked() },
                     onSearchClicked = { updateSearchBarState(SearchBarState.OPENED) },
-                    onLocalSearchClicked = { mainViewModel.setLocalSearchActive(true) },
+                    onLocalSearchClicked = { onSetLocalSearchActive(true) },
                     scrollBehavior = scrollBehavior,
                     showLocalSearchIcon = isOnLocalFilesScreen
                 )
             }
         }
     }
-
-
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -114,14 +117,11 @@ fun LocalSearchAppBar(
         focusRequester.requestFocus()
     }
 
-    // SearchBar와 유사한 스타일의 검색바
-    // - 파일 목록이 아래에 보여야 하므로 fullscreen SearchBar 대신 커스텀 구현
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .background(Color.White)
     ) {
-        // 검색 입력 영역
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -129,7 +129,6 @@ fun LocalSearchAppBar(
                 .padding(horizontal = 8.dp),
             verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
         ) {
-            // 뒤로가기 버튼
             IconButton(onClick = onClose) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -138,7 +137,6 @@ fun LocalSearchAppBar(
                 )
             }
 
-            // 검색 입력 필드
             Box(
                 modifier = Modifier
                     .weight(1f)
@@ -176,7 +174,6 @@ fun LocalSearchAppBar(
                 )
             }
 
-            // Clear 버튼
             if (query.isNotEmpty()) {
                 IconButton(onClick = { onQueryChange("") }) {
                     Icon(
@@ -190,7 +187,6 @@ fun LocalSearchAppBar(
             }
         }
 
-        // 하단 구분선
         HorizontalDivider(
             color = Color.LightGray,
             thickness = 1.dp
@@ -201,14 +197,14 @@ fun LocalSearchAppBar(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CustomSearchAppBar(
-    mainViewModel: MainViewModel,
+    searchQuery: String,
+    suggestionKeywords: List<String>,
+    onUpdateSearchQuery: (String) -> Unit,
+    onClearSearchQuery: () -> Unit,
     updateSearchBarState: (SearchBarState) -> Unit,
     onSearchClicked: (String) -> Unit,
     focusRequester: FocusRequester,
 ) {
-
-    val searchQuery by mainViewModel.searchQuery.collectAsStateWithLifecycle()
-    val suggestionKeywords by mainViewModel.suggestionKeywords.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
 
@@ -221,17 +217,17 @@ fun CustomSearchAppBar(
             .fillMaxWidth()
             .focusRequester(focusRequester),
         query = searchQuery,
-        onQueryChange = mainViewModel::updateSearchQuery,
+        onQueryChange = onUpdateSearchQuery,
         onSearch = {
             onSearchClicked(it)
-            mainViewModel.clearSearchQuery()
+            onClearSearchQuery()
         },
         active = true,
         placeholder = { Text(text = stringResource(id = R.string.searchView_hint)) },
         leadingIcon = {
             IconButton(onClick = {
                 updateSearchBarState(SearchBarState.CLOSED)
-                mainViewModel.clearSearchQuery()
+                onClearSearchQuery()
             }) {
                 Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
             }
@@ -243,7 +239,7 @@ fun CustomSearchAppBar(
                 }
             } else {
                 IconButton(onClick = {
-                    mainViewModel.clearSearchQuery()
+                    onClearSearchQuery()
                 }) {
                     Icon(Icons.Default.Close, contentDescription = "Clear Text")
                 }
@@ -268,14 +264,14 @@ fun CustomSearchAppBar(
                         suggestionText = suggestionKeyword,
                         onClick = {
                             onSearchClicked(suggestionKeyword)
-                            mainViewModel.clearSearchQuery()
+                            onClearSearchQuery()
                         },
                     )
                 }
 
             }
             BackHandler {
-                mainViewModel.clearSearchQuery()
+                onClearSearchQuery()
                 updateSearchBarState(SearchBarState.CLOSED)
             }
         }
@@ -348,4 +344,3 @@ fun DefaultAppBar(
     )
 
 }
-

--- a/feature/main/src/main/java/com/example/main/components/bottomsheet/PlayerBottomSheet.kt
+++ b/feature/main/src/main/java/com/example/main/components/bottomsheet/PlayerBottomSheet.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -25,7 +24,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
@@ -39,6 +37,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.lerp
 import androidx.compose.ui.util.trace
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
@@ -75,30 +74,22 @@ fun PlayerBottomSheet(
     onNavigateToChannelScreen: (String) -> Unit
 ) = trace("PlayerBottomSheet") {
 
+    // ===== Collect all states here =====
+    val mediaController by mainViewModel.mediaControllerFlow.collectAsStateWithLifecycle()
+    val isPlaying by mainViewModel.isPlaying.collectAsStateWithLifecycle()
+    val currentItem by mainViewModel.currentItem.collectAsStateWithLifecycle()
+    val videoDetailUiState by mainViewModel.videoDetailUiState.collectAsStateWithLifecycle()
+    val pitchValue by mainViewModel.pitchValue.collectAsStateWithLifecycle()
+    val tempoValue by mainViewModel.tempoValue.collectAsStateWithLifecycle()
+    val myPlaylists by mainViewModel.myPlaylists.collectAsStateWithLifecycle()
+    val currentPlaylist by mainViewModel.currentPlaylist.collectAsStateWithLifecycle()
+    val currentPlaylistInfo by mainViewModel.currentPlaylistInfo.collectAsStateWithLifecycle()
+    val videoQuality by mainViewModel.videoQuality.collectAsStateWithLifecycle()
+
     val coroutineScope = rememberCoroutineScope()
     var showPlaylistModal by remember { mutableStateOf(false) }
     var showQualityModal by remember { mutableStateOf(false) }
     var isControllerVisible by remember { mutableStateOf(false) }
-    val mediaController by mainViewModel.mediaControllerFlow.collectAsState()
-
-//    val bottomSheetAlpha = remember(bottomSheetOffset) {
-//        if (bottomSheetOffset < 0) 1f else {
-//            when {
-//                bottomSheetOffset < 0.2f -> {
-//                    val alphaValue = (0.2 - bottomSheetOffset) / 0.2
-//                    alphaValue
-//                }
-//
-//                else -> 0f
-//            }
-//        }
-//    }
-
-//    val mainBackgroundAlpha = remember(bottomSheetOffset) {
-//        if (bottomSheetOffset < 0) 1f else {
-//            bottomSheetOffset.pow(3).coerceAtLeast(0f)
-//        }
-//    }
 
     var playerViewHeight by remember { mutableIntStateOf(0) }
 
@@ -114,7 +105,9 @@ fun PlayerBottomSheet(
 
     if (showQualityModal) {
         VideoQualityBottomSheet(
-            mainViewModel = mainViewModel,
+            videoDetailUiState = videoDetailUiState,
+            currentQuality = videoQuality,
+            onSetVideoQuality = mainViewModel::setVideoQuality,
             onDismiss = { showQualityModal = false }
         )
     }
@@ -143,7 +136,10 @@ fun PlayerBottomSheet(
         PlayerBottomSheetHeader(
             bottomSheetOffset = bottomSheetOffset,
             bottomSheetState = bottomSheetState,
-            mainViewModel = mainViewModel
+            isPlaying = isPlaying,
+            displayTitle = currentItem?.title ?: "",
+            onPlayPause = mainViewModel::playPause,
+            onStop = mainViewModel::stopPlayback
         )
 
         Column(
@@ -188,33 +184,35 @@ fun PlayerBottomSheet(
                                 }
                             }
                         }, update = { view ->
-                            mediaController?.let { controller ->
+                            val controller = mediaController
+                            if (view.player != controller) {
                                 view.player = controller
-                            } ?: run {
-                                view.player = null
                             }
-                            view.useController = when (bottomSheetState.currentValue) {
-                                SheetValue.Expanded -> true
-                                else -> false
+                            val shouldShowController = bottomSheetState.currentValue == SheetValue.Expanded
+                            if (view.useController != shouldShowController) {
+                                view.useController = shouldShowController
                             }
                         }, modifier = Modifier.fillMaxSize()
                     )
                 }
                 trace("PlayerThumbnailView") {
                     PlayerThumbnailView(
-                        mainViewModel = mainViewModel,
+                        videoDetailUiState = videoDetailUiState,
+                        currentItem = currentItem,
                         modifier = Modifier
                             .fillMaxSize()
                             .semantics { contentDescription = "PlayerThumbnailView" })
                 }
                 trace("PlayerLoadingIndicator") {
                     PlayerLoadingIndicator(
-                        mainViewModel = mainViewModel, modifier = Modifier.align(Alignment.Center)
+                        videoDetailUiState = videoDetailUiState,
+                        currentItem = currentItem,
+                        modifier = Modifier.align(Alignment.Center)
                     )
                 }
                 if (isControllerVisible && bottomSheetState.currentValue == SheetValue.Expanded) {
                     QualityIndicatorButton(
-                        mainViewModel = mainViewModel,
+                        videoQuality = videoQuality,
                         onClick = { showQualityModal = true },
                         modifier = Modifier
                             .align(Alignment.TopEnd)
@@ -223,7 +221,19 @@ fun PlayerBottomSheet(
                 }
             }
             VideoDetailPanel(
-                mainViewModel = mainViewModel,
+                videoDetailUiState = videoDetailUiState,
+                currentItem = currentItem,
+                myPlaylists = myPlaylists,
+                pitchValue = pitchValue,
+                tempoValue = tempoValue,
+                onPlayVideo = mainViewModel::playVideo,
+                onPitchPlusOne = mainViewModel::pitchPlusOne,
+                onPitchMinusOne = mainViewModel::pitchMinusOne,
+                onPitchInit = mainViewModel::initPitchValue,
+                onTempoPlusOne = mainViewModel::tempoPlusOne,
+                onTempoMinusOne = mainViewModel::tempoMinusOne,
+                onTempoInit = mainViewModel::initTempoValue,
+                onAddItemToPlaylist = mainViewModel::addItemToPlaylist,
                 onNavigateToChannelScreen = onNavigateToChannelScreen,
                 bottomSheetState = bottomSheetState,
                 modifier = Modifier
@@ -238,7 +248,8 @@ fun PlayerBottomSheet(
             )
         }
         PlaylistFloatingButton(
-            mainViewModel = mainViewModel,
+            currentPlaylist = currentPlaylist,
+            playlistTitle = currentPlaylistInfo?.title,
             bottomSheetState = bottomSheetState,
             onClick = { showPlaylistModal = true },
             bottomSheetOffset = bottomSheetOffset,
@@ -252,10 +263,8 @@ fun PlayerBottomSheet(
 
 
 private fun Modifier.changeMainBackgroundAlpha(bottomSheetOffset: Float): Modifier {
-    if (bottomSheetOffset < 0) return alpha(1f)
-    return this.alpha((bottomSheetOffset.pow(3)).coerceAtLeast(0f))
-
-
+    if (bottomSheetOffset < 0) return this.graphicsLayer { alpha = 1f }
+    return this.graphicsLayer { alpha = (bottomSheetOffset.pow(3)).coerceAtLeast(0f) }
 }
 
 private fun calculateDefaultScaleX(bottomSheetOffset: Float): Float {
@@ -274,19 +283,17 @@ private fun calculateScaleFactorY(bottomSheetOffset: Float): Float {
 
 @Composable
 private fun QualityIndicatorButton(
-    mainViewModel: MainViewModel,
+    videoQuality: com.example.domain.model.preferences.VideoQuality,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val currentQuality by mainViewModel.videoQuality.collectAsState()
-
     Surface(
         modifier = modifier.clickable(onClick = onClick),
         shape = RoundedCornerShape(4.dp),
         color = Color.Black.copy(alpha = 0.6f)
     ) {
         Text(
-            text = stringResource(currentQuality.getDisplayStringResId()),
+            text = stringResource(videoQuality.getDisplayStringResId()),
             modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             color = Color.White,
             fontSize = 12.sp,

--- a/feature/main/src/main/java/com/example/main/components/bottomsheet/PlayerBottomSheetScaffold.kt
+++ b/feature/main/src/main/java/com/example/main/components/bottomsheet/PlayerBottomSheetScaffold.kt
@@ -1,6 +1,5 @@
 package com.example.main.components.bottomsheet
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
@@ -14,6 +13,8 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
@@ -47,6 +48,7 @@ fun PlayerBottomSheetScaffold(
     bottomSheetOffset: () -> Float,
     onNavigateToChannelScreen: (String) -> Unit,
     isLocalSearchActive: Boolean,
+    onStopPlayback: () -> Unit,
     content: @Composable (PaddingValues) -> Unit,
 ) {
     val density = LocalDensity.current
@@ -78,20 +80,23 @@ fun PlayerBottomSheetScaffold(
         }
     }
 
-    val currentOffset = bottomSheetOffset()
-    // isLocalSearchActive가 true면 BottomNav가 숨겨지므로 패딩 불필요
-    val scaffoldBottomPadding = if (isLocalSearchActive) {
-        0.dp
-    } else {
-        when {
-            currentOffset <= 0.0f -> {
-                val progress = (currentOffset * 25).coerceIn(-1f, 0f)
-                (56 * (1 + progress)).coerceAtLeast(0f).dp
-            }
-            currentOffset >= 1.0f -> 56.dp
-            else -> {
-                val progress = currentOffset.coerceIn(0f, 1f)
-                (56 * progress).dp
+    val scaffoldBottomPadding by remember {
+        derivedStateOf {
+            val currentOffset = bottomSheetOffset()
+            if (isLocalSearchActive) {
+                0.dp
+            } else {
+                when {
+                    currentOffset <= 0.0f -> {
+                        val progress = (currentOffset * 25).coerceIn(-1f, 0f)
+                        (56 * (1 + progress)).coerceAtLeast(0f).dp
+                    }
+                    currentOffset >= 1.0f -> 56.dp
+                    else -> {
+                        val progress = currentOffset.coerceIn(0f, 1f)
+                        (56 * progress).dp
+                    }
+                }
             }
         }
     }
@@ -100,7 +105,7 @@ fun PlayerBottomSheetScaffold(
         snapshotFlow { bottomSheetState.currentValue }.collect {
             when (it) {
                 SheetValue.Hidden -> {
-                    mainViewModel.stopPlayback()
+                    onStopPlayback()
                 }
 
                 SheetValue.Expanded -> {}
@@ -140,4 +145,3 @@ fun PlayerBottomSheetScaffold(
         }
     }
 }
-

--- a/feature/main/src/main/java/com/example/main/components/bottomsheet/PlaylistModalBottomSheet.kt
+++ b/feature/main/src/main/java/com/example/main/components/bottomsheet/PlaylistModalBottomSheet.kt
@@ -19,8 +19,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -32,8 +30,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.domain.model.playable.PlayableItem
 import com.example.domain.model.preferences.RepeatMode
-import com.example.main.MainViewModel
+import com.example.domain.model.youtube.playlist.Playlist
 import com.example.main.R
 import com.example.main.components.bottomsheet.item.PlaylistBottomSheetItem
 
@@ -41,16 +40,16 @@ import com.example.main.components.bottomsheet.item.PlaylistBottomSheetItem
 @Composable
 fun PlaylistModalBottomSheet(
     onDismiss: () -> Unit,
-    mainViewModel: MainViewModel,
+    currentPlaylist: List<PlayableItem>,
+    currentPlaylistIndex: Int,
+    currentPlaylistInfo: Playlist?,
+    repeatMode: RepeatMode,
+    shuffleMode: Boolean,
+    onPlayPlaylistItems: (List<PlayableItem>, Int) -> Unit,
+    onToggleRepeatMode: () -> Unit,
+    onToggleShuffleMode: () -> Unit,
     playerViewHeight: Int,
 ) {
-
-    val currentPlaylist by mainViewModel.currentPlaylist.collectAsState()
-    val currentPlaylistIndex by mainViewModel.currentPlaylistIndex.collectAsState()
-    val currentPlaylistInfo by mainViewModel.currentPlaylistInfo.collectAsState()
-
-    val repeatMode by mainViewModel.repeatMode.collectAsState()
-    val shuffleMode by mainViewModel.shuffleMode.collectAsState()
 
     val sheetState = rememberModalBottomSheetState(
         skipPartiallyExpanded = true,
@@ -119,7 +118,7 @@ fun PlaylistModalBottomSheet(
                     .padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                IconButton(onClick = { mainViewModel.toggleRepeatMode() }) {
+                IconButton(onClick = onToggleRepeatMode) {
                     Icon(
                         painter = painterResource(
                             id = when (repeatMode) {
@@ -130,12 +129,11 @@ fun PlaylistModalBottomSheet(
                         ),
                         contentDescription = "Repeat",
                         modifier = Modifier.size(36.dp),
-                        // 활성화 상태에 따라 색상 변경
                         tint = if (repeatMode == RepeatMode.OFF) Color.Gray else Color(0xFF3F51B5)
                     )
                 }
                 IconButton(
-                    onClick = { mainViewModel.toggleShuffleMode() },
+                    onClick = onToggleShuffleMode,
                     modifier = Modifier.padding(start = 8.dp)
                 ) {
                     Icon(
@@ -144,7 +142,6 @@ fun PlaylistModalBottomSheet(
                         ),
                         contentDescription = "Shuffle",
                         modifier = Modifier.size(36.dp),
-                        // 활성화 상태에 따라 색상 변경
                         tint = if (shuffleMode) Color(0xFF3F51B5) else Color.Gray
                     )
                 }
@@ -183,10 +180,7 @@ fun PlaylistModalBottomSheet(
                         PlaylistBottomSheetItem(
                             item = item,
                             onClick = {
-                                mainViewModel.playPlaylistItems(
-                                    playlist = currentPlaylist,
-                                    startIndex = index
-                                )
+                                onPlayPlaylistItems(currentPlaylist, index)
                             },
                             isCurrentlyPlaying = index == currentPlaylistIndex
                         )

--- a/feature/main/src/main/java/com/example/main/components/bottomsheet/PlaylistModalBottomSheetContainer.kt
+++ b/feature/main/src/main/java/com/example/main/components/bottomsheet/PlaylistModalBottomSheetContainer.kt
@@ -1,12 +1,8 @@
 package com.example.main.components.bottomsheet
 
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.dp
 import com.example.main.MainViewModel
 
 @Composable
@@ -15,11 +11,22 @@ fun PlaylistModalBottomSheetContainer(
     mainViewModel: MainViewModel,
     playerViewHeight: Int,
 ) {
+    val currentPlaylist by mainViewModel.currentPlaylist.collectAsStateWithLifecycle()
+    val currentPlaylistIndex by mainViewModel.currentPlaylistIndex.collectAsStateWithLifecycle()
+    val currentPlaylistInfo by mainViewModel.currentPlaylistInfo.collectAsStateWithLifecycle()
+    val repeatMode by mainViewModel.repeatMode.collectAsStateWithLifecycle()
+    val shuffleMode by mainViewModel.shuffleMode.collectAsStateWithLifecycle()
 
     PlaylistModalBottomSheet(
         onDismiss = onDismiss,
-        mainViewModel = mainViewModel,
+        currentPlaylist = currentPlaylist,
+        currentPlaylistIndex = currentPlaylistIndex,
+        currentPlaylistInfo = currentPlaylistInfo,
+        repeatMode = repeatMode,
+        shuffleMode = shuffleMode,
+        onPlayPlaylistItems = mainViewModel::playPlaylistItems,
+        onToggleRepeatMode = mainViewModel::toggleRepeatMode,
+        onToggleShuffleMode = mainViewModel::toggleShuffleMode,
         playerViewHeight = playerViewHeight
     )
-
 }

--- a/feature/main/src/main/java/com/example/main/components/bottomsheet/VideoQualityBottomSheet.kt
+++ b/feature/main/src/main/java/com/example/main/components/bottomsheet/VideoQualityBottomSheet.kt
@@ -19,13 +19,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.example.main.MainViewModel
 import androidx.compose.material3.Surface
 import androidx.compose.ui.graphics.Color
 import com.example.domain.model.preferences.VideoQuality
@@ -36,12 +33,11 @@ import com.example.ui.util.getDisplayStringResId
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun VideoQualityBottomSheet(
-    mainViewModel: MainViewModel,
+    videoDetailUiState: VideoDetailUiState,
+    currentQuality: VideoQuality,
+    onSetVideoQuality: (VideoQuality) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val videoDetailUiState by mainViewModel.videoDetailUiState.collectAsState()
-    val currentQuality by mainViewModel.videoQuality.collectAsState()
-
     // itag -> VideoQuality mapping
     val itagToQualityMap = mapOf(
         137 to VideoQuality.P1080, 248 to VideoQuality.P1080,
@@ -92,7 +88,7 @@ fun VideoQualityBottomSheet(
                         qualityLabel = stringResource(R.string.video_quality_auto),
                         isSelected = currentQuality.isAuto,
                         onClick = {
-                            mainViewModel.setVideoQuality(VideoQuality.AUTO)
+                            onSetVideoQuality(VideoQuality.AUTO)
                             onDismiss()
                         }
                     )
@@ -107,7 +103,7 @@ fun VideoQualityBottomSheet(
                             qualityLabel = stringResource(quality.getDisplayStringResId()),
                             isSelected = currentQuality == quality,
                             onClick = {
-                                mainViewModel.setVideoQuality(quality)
+                                onSetVideoQuality(quality)
                                 onDismiss()
                             }
                         )

--- a/feature/main/src/main/java/com/example/main/components/bottomsheet/item/ChannelSection.kt
+++ b/feature/main/src/main/java/com/example/main/components/bottomsheet/item/ChannelSection.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -38,7 +37,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.example.domain.model.playable.PlayableItem
 import com.example.domain.model.youtube.video_detail.VideoDetail
-import com.example.main.MainViewModel
+import com.example.domain.model.library.MyPlaylist
 import com.example.main.R
 import com.example.main.components.bottomsheet.state.VideoDetailUiState
 import com.example.ui.components.dialog.AddItemToPlaylistDialog
@@ -52,20 +51,20 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChannelSection(
-    mainViewModel: MainViewModel,
+    videoDetailUiState: VideoDetailUiState,
+    currentItem: PlayableItem?,
+    myPlaylists: List<MyPlaylist>,
+    onAddItemToPlaylist: (PlayableItem, Long) -> Unit,
     bottomSheetState: SheetState,
     onNavigateToChannelScreen: (String) -> Unit
 ) {
     var isShowingPlaylistDialog by remember { mutableStateOf(false) }
-    val myPlaylists by mainViewModel.myPlaylists.collectAsState()
     val context = LocalContext.current
-    val videoDetailUiState by mainViewModel.videoDetailUiState.collectAsState()
-    val currentItem by mainViewModel.currentItem.collectAsState()
 
     when (currentItem) {
         is PlayableItem.Local -> {
             LocalFileSectionContent(
-                localItem = currentItem as PlayableItem.Local,
+                localItem = currentItem,
                 onAddButtonClicked = { isShowingPlaylistDialog = true }
             )
         }
@@ -77,7 +76,6 @@ fun ChannelSection(
                 is VideoDetailUiState.Success -> {
                     ChannelSectionContent(
                         videoDetail = state.videoDetail!!,
-                        mainViewModel = mainViewModel,
                         onAddButtonClicked = { isShowingPlaylistDialog = true },
                         onNavigateToChannelScreen = onNavigateToChannelScreen,
                         bottomSheetState = bottomSheetState
@@ -97,7 +95,7 @@ fun ChannelSection(
             onDismiss = { isShowingPlaylistDialog = false },
             onPlaylistSelected = { playlistId ->
                 currentItem?.let {
-                    mainViewModel.addItemToPlaylist(it, playlistId)
+                    onAddItemToPlaylist(it, playlistId)
                     ToastUtil.showShort(
                         context = context,
                         message = context.getString(R.string.notify_video_added_to_playlist)
@@ -112,7 +110,6 @@ fun ChannelSection(
 @Composable
 fun ChannelSectionContent(
     videoDetail: VideoDetail,
-    mainViewModel: MainViewModel,
     onAddButtonClicked: () -> Unit,
     bottomSheetState: SheetState,
     onNavigateToChannelScreen: (String) -> Unit
@@ -266,6 +263,3 @@ fun ChannelSectionShimmer() {
         Spacer(modifier = Modifier.weight(1f))
     }
 }
-
-
-

--- a/feature/main/src/main/java/com/example/main/components/bottomsheet/item/PitchControlItem.kt
+++ b/feature/main/src/main/java/com/example/main/components/bottomsheet/item/PitchControlItem.kt
@@ -15,8 +15,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,16 +23,17 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.example.main.MainViewModel
 import com.example.main.R
 import com.example.util.ToastUtil
 
 @Composable
 fun PitchControlItem(
-    mainViewModel: MainViewModel
+    pitchValue: Int,
+    onPlusOne: () -> Unit,
+    onMinusOne: () -> Unit,
+    onInit: () -> Unit
 ) {
     val context = LocalContext.current
-    val pitchValue by mainViewModel.pitchValue.collectAsState()
 
     val actualValue = remember(pitchValue) {
         (pitchValue * 0.1) - 10.0
@@ -62,7 +61,7 @@ fun PitchControlItem(
                     .weight(1f)
                     .fillMaxHeight()
                     .clickable {
-                        mainViewModel.pitchMinusOne()
+                        onMinusOne()
                         ToastUtil.showShort(context, String.format(context.getString(R.string.pitch_minus_text), actualValue - 1))
                     },
                 contentAlignment = Alignment.Center
@@ -77,7 +76,7 @@ fun PitchControlItem(
                     .weight(1f)
                     .fillMaxHeight()
                     .clickable {
-                        mainViewModel.initPitchValue()
+                        onInit()
                         ToastUtil.showShort(context, context.getString(R.string.pitch_initialize_text, 0.0))
                     },
                 contentAlignment = Alignment.Center
@@ -93,7 +92,7 @@ fun PitchControlItem(
                     .weight(1f)
                     .fillMaxHeight()
                     .clickable {
-                        mainViewModel.pitchPlusOne()
+                        onPlusOne()
                         ToastUtil.showShort(context, context.getString(R.string.pitch_plus_text, actualValue + 1))
                     },
                 contentAlignment = Alignment.Center

--- a/feature/main/src/main/java/com/example/main/components/bottomsheet/item/PlayerBottomSheetHeader.kt
+++ b/feature/main/src/main/java/com/example/main/components/bottomsheet/item/PlayerBottomSheetHeader.kt
@@ -15,8 +15,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -26,7 +24,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.trace
-import com.example.main.MainViewModel
 import com.example.main.R
 import com.example.main.components.bottomsheet.GraphicsLayerConstants.PEEK_HEIGHT
 import com.example.util.constants.AppColors
@@ -37,15 +34,13 @@ import kotlinx.coroutines.launch
 fun PlayerBottomSheetHeader(
     bottomSheetOffset: () -> Float,
     bottomSheetState: SheetState,
-    mainViewModel: MainViewModel,
+    isPlaying: Boolean,
+    displayTitle: String,
+    onPlayPause: () -> Unit,
+    onStop: () -> Unit,
 ) {
 
     val coroutineScope = rememberCoroutineScope()
-
-    val isPlaying by mainViewModel.isPlaying.collectAsState()
-    val currentItem by mainViewModel.currentItem.collectAsState()
-
-    val displayTitle = currentItem?.title ?: ""
 
     trace("PlayerBottomSheetHeader") {
         Row(
@@ -74,7 +69,7 @@ fun PlayerBottomSheetHeader(
             )
 
             IconButton(
-                onClick = { mainViewModel.playPause() },
+                onClick = onPlayPause,
                 modifier = Modifier
                     .padding(end = 5.dp)
                     .graphicsLayer {
@@ -90,7 +85,7 @@ fun PlayerBottomSheetHeader(
 
             IconButton(
                 onClick = {
-                    mainViewModel.stopPlayback()
+                    onStop()
                     coroutineScope.launch { bottomSheetState.hide() }
                 },
                 modifier = Modifier

--- a/feature/main/src/main/java/com/example/main/components/bottomsheet/item/PlayerLoadingIndicator.kt
+++ b/feature/main/src/main/java/com/example/main/components/bottomsheet/item/PlayerLoadingIndicator.kt
@@ -2,21 +2,17 @@ package com.example.main.components.bottomsheet.item
 
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.example.domain.model.playable.PlayableItem
-import com.example.main.MainViewModel
 import com.example.main.components.bottomsheet.state.VideoDetailUiState
 import com.example.util.constants.AppColors
 
 @Composable
 fun PlayerLoadingIndicator(
-    mainViewModel: MainViewModel, modifier: Modifier = Modifier
+    videoDetailUiState: VideoDetailUiState,
+    currentItem: PlayableItem?,
+    modifier: Modifier = Modifier
 ) {
-    val videoDetailUiState by mainViewModel.videoDetailUiState.collectAsState()
-    val currentItem by mainViewModel.currentItem.collectAsState()
-
     if (currentItem is PlayableItem.Local) return
 
     when (val state = videoDetailUiState){

--- a/feature/main/src/main/java/com/example/main/components/bottomsheet/item/PlayerThumbnailView.kt
+++ b/feature/main/src/main/java/com/example/main/components/bottomsheet/item/PlayerThumbnailView.kt
@@ -3,25 +3,20 @@ package com.example.main.components.bottomsheet.item
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
 import coil.compose.AsyncImage
 import com.example.domain.model.playable.PlayableItem
-import com.example.main.MainViewModel
 import com.example.main.components.bottomsheet.state.VideoDetailUiState
 import com.example.util.constants.AppColors
 
 @Composable
 fun PlayerThumbnailView(
-    mainViewModel: MainViewModel,
+    videoDetailUiState: VideoDetailUiState,
+    currentItem: PlayableItem?,
     modifier: Modifier = Modifier
 ) {
-    val videoDetailUiState by mainViewModel.videoDetailUiState.collectAsState()
-    val currentItem by mainViewModel.currentItem.collectAsState()
-
     if (currentItem is PlayableItem.Local) return
 
     when (val state = videoDetailUiState) {
@@ -40,5 +35,3 @@ fun PlayerThumbnailView(
         else -> {}
     }
 }
-
-

--- a/feature/main/src/main/java/com/example/main/components/bottomsheet/item/PlaylistFloatingButton.kt
+++ b/feature/main/src/main/java/com/example/main/components/bottomsheet/item/PlaylistFloatingButton.kt
@@ -15,11 +15,8 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
@@ -27,7 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.main.MainViewModel
+import com.example.domain.model.playable.PlayableItem
 import com.example.main.R
 import com.example.ui.theme.blendColors
 import com.example.util.constants.AppColors
@@ -35,15 +32,13 @@ import com.example.util.constants.AppColors
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PlaylistFloatingButton(
-    mainViewModel: MainViewModel,
+    currentPlaylist: List<PlayableItem>,
+    playlistTitle: String?,
     bottomSheetState: SheetState,
     onClick: () -> Unit,
     bottomSheetOffset: () -> Float,
     modifier: Modifier = Modifier
 ) {
-    val currentPlaylist by mainViewModel.currentPlaylist.collectAsState()
-    val currentPlaylistInfo by mainViewModel.currentPlaylistInfo.collectAsState()
-
     if (currentPlaylist.isNotEmpty() && bottomSheetState.currentValue == SheetValue.Expanded) {
         val offset = bottomSheetOffset().coerceIn(0f, 1f)
         val backgroundColor = blendColors(AppColors.StatusBarBackground, AppColors.CharcoalGray, offset)
@@ -71,7 +66,7 @@ fun PlaylistFloatingButton(
                 )
 
                 Text(
-                    text = currentPlaylistInfo?.title
+                    text = playlistTitle
                         ?: stringResource(id = R.string.main_playlist_title),
                     modifier = Modifier.padding(horizontal = 8.dp),
                     fontWeight = FontWeight.Medium,

--- a/feature/main/src/main/java/com/example/main/components/bottomsheet/item/TempoControlItem.kt
+++ b/feature/main/src/main/java/com/example/main/components/bottomsheet/item/TempoControlItem.kt
@@ -15,8 +15,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,17 +23,18 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.example.main.MainViewModel
 import com.example.main.R
 import com.example.util.ToastUtil
 
 
 @Composable
 fun TempoControlItem(
-    mainViewModel: MainViewModel
+    tempoValue: Int,
+    onPlusOne: () -> Unit,
+    onMinusOne: () -> Unit,
+    onInit: () -> Unit
 ) {
     val context = LocalContext.current
-    val tempoValue by mainViewModel.tempoValue.collectAsState()
     val actualValue = remember(tempoValue) {
         (tempoValue * 0.1) - 10.0
     }
@@ -62,7 +61,7 @@ fun TempoControlItem(
                     .weight(1f)
                     .fillMaxHeight()
                     .clickable {
-                        mainViewModel.tempoMinusOne()
+                        onMinusOne()
                         ToastUtil.showShort(
                             context,
                             context.getString(R.string.tempo_minus_text, actualValue - 1)
@@ -80,7 +79,7 @@ fun TempoControlItem(
                     .weight(1f)
                     .fillMaxHeight()
                     .clickable {
-                        mainViewModel.initTempoValue()
+                        onInit()
                         ToastUtil.showShort(context, context.getString(R.string.tempo_init_text, 0.0))
                     },
                 contentAlignment = Alignment.Center
@@ -96,7 +95,7 @@ fun TempoControlItem(
                     .weight(1f)
                     .fillMaxHeight()
                     .clickable {
-                        mainViewModel.tempoPlusOne()
+                        onPlusOne()
                         ToastUtil.showShort(
                             context,
                             context.getString(R.string.tempo_plus_text, actualValue + 1)

--- a/feature/main/src/main/java/com/example/main/components/bottomsheet/item/VideoDetailPanel.kt
+++ b/feature/main/src/main/java/com/example/main/components/bottomsheet/item/VideoDetailPanel.kt
@@ -5,13 +5,11 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import com.example.domain.model.library.MyPlaylist
 import com.example.domain.model.playable.PlayableItem
-import com.example.main.MainViewModel
+import com.example.domain.model.youtube.video.Video
 import com.example.main.components.bottomsheet.state.VideoDetailUiState
 import com.example.ui.components.items.CommonVideoItem
 import kotlinx.coroutines.launch
@@ -19,16 +17,23 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun VideoDetailPanel(
-    mainViewModel: MainViewModel,
+    videoDetailUiState: VideoDetailUiState,
+    currentItem: PlayableItem?,
+    myPlaylists: List<MyPlaylist>,
+    pitchValue: Int,
+    tempoValue: Int,
+    onPlayVideo: (Video) -> Unit,
+    onPitchPlusOne: () -> Unit,
+    onPitchMinusOne: () -> Unit,
+    onPitchInit: () -> Unit,
+    onTempoPlusOne: () -> Unit,
+    onTempoMinusOne: () -> Unit,
+    onTempoInit: () -> Unit,
+    onAddItemToPlaylist: (PlayableItem, Long) -> Unit,
     onNavigateToChannelScreen: (String) -> Unit,
     bottomSheetState: SheetState,
     modifier: Modifier,
 ) {
-
-    val videoDetailUiState by mainViewModel.videoDetailUiState.collectAsState()
-    val currentItem by mainViewModel.currentItem.collectAsState()
-
-    val compositionTimestamp = remember { System.currentTimeMillis() }
 
     val listState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
@@ -39,14 +44,29 @@ fun VideoDetailPanel(
         modifier = modifier,
         state = listState
     ) {
-        item(key = "header_${compositionTimestamp}") {
-            VideoInfoHeader(mainViewModel, onNavigateToChannelScreen, bottomSheetState)
+        item(key = "header") {
+            VideoInfoHeader(
+                currentItem = currentItem,
+                videoDetailUiState = videoDetailUiState,
+                myPlaylists = myPlaylists,
+                pitchValue = pitchValue,
+                tempoValue = tempoValue,
+                onPitchPlusOne = onPitchPlusOne,
+                onPitchMinusOne = onPitchMinusOne,
+                onPitchInit = onPitchInit,
+                onTempoPlusOne = onTempoPlusOne,
+                onTempoMinusOne = onTempoMinusOne,
+                onTempoInit = onTempoInit,
+                onAddItemToPlaylist = onAddItemToPlaylist,
+                onNavigateToChannelScreen = onNavigateToChannelScreen,
+                bottomSheetState = bottomSheetState
+            )
         }
 
         if (!isLocalFile) {
             when (val state = videoDetailUiState) {
                 is VideoDetailUiState.Loading -> {
-                    items(5, key = { "shimmer_${compositionTimestamp}_$it" }) {
+                    items(5, key = { "shimmer_$it" }) {
                         RelatedVideoShimmerItem()
                     }
                 }
@@ -56,14 +76,13 @@ fun VideoDetailPanel(
                     items?.let { videoList ->
                         items(
                             count = videoList.size,
-                            key = { index -> "item_${compositionTimestamp}_${index}_${videoList[index].id}" }
-
+                            key = { index -> videoList[index].id }
                         ) { index ->
                             val item = videoList[index]
                             CommonVideoItem(
                                 item = item,
                                 onClick = {
-                                    mainViewModel.playVideo(item)
+                                    onPlayVideo(item)
                                     coroutineScope.launch {
                                         listState.animateScrollToItem(0)
                                     }

--- a/feature/main/src/main/java/com/example/main/components/bottomsheet/item/VideoInfoHeader.kt
+++ b/feature/main/src/main/java/com/example/main/components/bottomsheet/item/VideoInfoHeader.kt
@@ -4,23 +4,49 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SheetState
 import androidx.compose.runtime.Composable
-import com.example.main.MainViewModel
+import com.example.domain.model.library.MyPlaylist
+import com.example.domain.model.playable.PlayableItem
+import com.example.main.components.bottomsheet.state.VideoDetailUiState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun VideoInfoHeader(
-    mainViewModel: MainViewModel,
+    currentItem: PlayableItem?,
+    videoDetailUiState: VideoDetailUiState,
+    myPlaylists: List<MyPlaylist>,
+    pitchValue: Int,
+    tempoValue: Int,
+    onPitchPlusOne: () -> Unit,
+    onPitchMinusOne: () -> Unit,
+    onPitchInit: () -> Unit,
+    onTempoPlusOne: () -> Unit,
+    onTempoMinusOne: () -> Unit,
+    onTempoInit: () -> Unit,
+    onAddItemToPlaylist: (PlayableItem, Long) -> Unit,
     onNavigateToChannelScreen: (String) -> Unit,
     bottomSheetState: SheetState
 ) {
     Column {
-        VideoInfoSection(mainViewModel = mainViewModel)
+        VideoInfoSection(currentItem = currentItem)
         ChannelSection(
-            mainViewModel = mainViewModel,
+            videoDetailUiState = videoDetailUiState,
+            currentItem = currentItem,
+            myPlaylists = myPlaylists,
+            onAddItemToPlaylist = onAddItemToPlaylist,
             onNavigateToChannelScreen = onNavigateToChannelScreen,
             bottomSheetState = bottomSheetState
         )
-        PitchControlItem(mainViewModel)
-        TempoControlItem(mainViewModel)
+        PitchControlItem(
+            pitchValue = pitchValue,
+            onPlusOne = onPitchPlusOne,
+            onMinusOne = onPitchMinusOne,
+            onInit = onPitchInit
+        )
+        TempoControlItem(
+            tempoValue = tempoValue,
+            onPlusOne = onTempoPlusOne,
+            onMinusOne = onTempoMinusOne,
+            onInit = onTempoInit
+        )
     }
 }

--- a/feature/main/src/main/java/com/example/main/components/bottomsheet/item/VideoInfoSection.kt
+++ b/feature/main/src/main/java/com/example/main/components/bottomsheet/item/VideoInfoSection.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -21,14 +19,12 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.domain.model.playable.PlayableItem
-import com.example.main.MainViewModel
 import com.example.main.R
 import com.example.util.TextFormatUtil
 import com.valentinilk.shimmer.shimmer
 
 @Composable
-fun VideoInfoSection(mainViewModel: MainViewModel) {
-    val currentItem by mainViewModel.currentItem.collectAsState()
+fun VideoInfoSection(currentItem: PlayableItem?) {
     val viewCountFormats = rememberStringArrayResource(R.array.view_count_formats)
 
     Column(
@@ -40,7 +36,7 @@ fun VideoInfoSection(mainViewModel: MainViewModel) {
             FullShimmerEffect()
         } else {
             VideoInfoContent(
-                item = currentItem!!,
+                item = currentItem,
                 viewCountFormats = viewCountFormats
             )
         }


### PR DESCRIPTION
  Follow-up to #19. Continues UI performance optimization with additional techniques.                                                                                                                                
   
  ## Changes                                                                                                                                                                                                         
                                                            
  ### 1. State Hoisting - PlayerBottomSheet (711d591)
  Remove ViewModel parameter from 13 child composables in PlayerBottomSheet hierarchy.
  Collect all StateFlow at PlayerBottomSheet level and pass values/callbacks to children,                                                                                                                            
  enabling Compose skip for unchanged parameters.
  Consolidates redundant subscriptions (e.g. `videoDetailUiState` collected 5x → 1x).                                                                                                                                
                                                                                                                                                                                                                     
  ### 2. State Hoisting - MainAppBar (2117d08)
  Remove ViewModel parameter from MainAppBar and CustomSearchAppBar.                                                                                                                                                 
  Pass search state and callbacks as parameters.            
  Apply `derivedStateOf` for status bar color and `scaffoldBottomPadding` to avoid per-frame recomposition during drag.                                                                                              
                                                                                                                                                                                                                     
  ### 3. Lifecycle-Aware Collection (d0ee18c)                                                                                                                                                                        
  Replace all `collectAsState` with `collectAsStateWithLifecycle` across every module (convert, home, library, core/ui).                                                                                             
  Stops unnecessary flow collection when the app is in background.                                                                                                                                                   
                                                                                                                                                                                                                     
  ### 4. Compose Stability Config (4727fc9)
  Add `compose-stability.conf` for `kotlin.collections.List`, `android.net.Uri`, and NewPipe extractor types.                                                                                                        
  Reduces `knownUnstableArguments` from 58 to 41.                                                                                                                                                                    
   
  ### 5. LazyColumn Keys (9f114e2)                                                                                                                                                                                   
  Apply `itemKey` in `EndlessLazyColumn`, add key parameter to `LibraryMyPlaylistItemScreen` and `AddItemToPlaylistDialog`.
  Remove timestamp-based keys in `VideoDetailPanel` that prevented item reuse.                                                                                                                                       
                                                                                                                                                                                                                     
  ### 6. Benchmark (8f01fff)                                                                                                                                                                                         
  Add `bottomSheetDragPerformance` benchmark test with `FrameTimingMetric` and `TraceSectionMetric`.                                                                                                                 
                                                                                                                                                                                                                     
  ## Benchmark Result Comparison (SM-N981N, Android 13)                                                                                                                                                              
                                                                                                                                                                                                                     
  ### Macrobenchmark Results (Before)                                                                                                                                                                                
                                                            
  | Metric | Min | Median | Max | P50 | P90 | P95 | P99 |                                                                                                                                                            
  |--------|-----|--------|-----|-----|-----|-----|-----|   
  | frameCount | 167.0 | 244.0 | 247.0 | – | – | – | – |                                                                                                                                                             
  | frameDurationCpuMs | – | – | – | 12.54 | 17.06 | 19.71 | 25.27 |                                                                                                                                                 
  | frameOverrunMs | – | – | – | -1.67 | 2.67 | 10.68 | 15.35 |                                                                                                                                                      
                                                                                                                                                                                                                     
  ### Macrobenchmark Results (After)                                                                                                                                                                                 
                                                                                                                                                                                                                     
  | Metric | Min | Median | Max | P50 | P90 | P95 | P99 |   
  |--------|-----|--------|-----|-----|-----|-----|-----|
  | frameCount | 169.0 | 240.0 | 247.0 | – | – | – | – |                                                                                                                                                             
  | frameDurationCpuMs | – | – | – | 11.92 | 15.90 | 17.01 | 19.77 |
  | frameOverrunMs | – | – | – | -2.14 | 1.30 | 2.47 | 7.92 |                                                                                                                                                        
                                                                                                                                                                                                                     
  ### Compose Compiler Metrics                                                                                                                                                                                       
                                                                                                                                                                                                                     
  | Metric | Before | After |                               
  |--------|--------|-------|
  | knownUnstableArguments | 58 | 41 |
  | knownStableArguments | 1687 | 1770 |                                                                                                                                                                             
  | memoizedLambdas | 154 | 168 |
  | ViewModel parameters | 16 | 3 |                

  ### Perfetto Trace                                                                                                                                                                                                 
   
  - [Before Trace (Google Drive)](https://drive.google.com/file/d/1pIfJlR8Iye8BDyXDmmoprPNRQR3nOptI/view?usp=sharing)                                                                                                
  - [After Trace (Google Drive)](https://drive.google.com/file/d/12k5Cu6wul-sTg8RNcxS3I-QW8OXebnyz/view?usp=drive_link)                                                                                                                                                                  
                                              