### PR TITLE
feat: support opening shared YouTube links

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,8 +52,23 @@
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="youtu.be" />
+                <data android:scheme="https" android:host="www.youtube.com" />
+                <data android:scheme="https" android:host="youtube.com" />
+                <data android:scheme="https" android:host="m.youtube.com" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/example/transpose/MainActivity.kt
+++ b/app/src/main/java/com/example/transpose/MainActivity.kt
@@ -1,15 +1,32 @@
 package com.example.transpose
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.lifecycle.lifecycleScope
+import com.example.data.newpipe.repository.base.NewPipeManager
+import com.example.domain.model.youtube.video.Video
 import com.example.main.MainScreen
+import com.example.media.manager.MediaPlaybackManager
 import com.example.ui.theme.TransposeTheme
 import dagger.hilt.android.AndroidEntryPoint
-
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var mediaPlaybackManager: MediaPlaybackManager
+
+    @Inject
+    lateinit var newPipeManager: NewPipeManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -19,6 +36,89 @@ class MainActivity : ComponentActivity() {
                 MainScreen()
             }
         }
+
+        handleExternalIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleExternalIntent(intent)
+    }
+
+    private fun handleExternalIntent(intent: Intent?) {
+        val candidate = when (intent?.action) {
+            Intent.ACTION_VIEW -> intent.dataString
+            Intent.ACTION_SEND -> intent.getStringExtra(Intent.EXTRA_TEXT)
+            else -> null
+        }
+
+        val youtubeUrl = extractYouTubeUrl(candidate) ?: return
+        val videoId = extractVideoId(youtubeUrl) ?: return
+
+        lifecycleScope.launch {
+            val video = withContext(Dispatchers.IO) {
+                runCatching { buildVideo(videoId) }.getOrNull()
+            } ?: return@launch
+
+            mediaPlaybackManager.mediaControllerFlow.filterNotNull().first()
+            mediaPlaybackManager.playSingleVideo(video)
+        }
+    }
+
+    private fun buildVideo(videoId: String): Video {
+        val extractor = newPipeManager.getStreamExtractor(videoId)
+        extractor.fetchPage()
+        val uploaderId = runCatching {
+            newPipeManager.getChannelId(extractor.uploaderUrl)
+        }.getOrDefault("")
+
+        return Video(
+            id = extractor.id,
+            title = extractor.name,
+            thumbnailUrl = extractor.thumbnails.firstOrNull()?.url,
+            description = extractor.description.content,
+            publishTimestamp = extractor.uploadDate?.offsetDateTime()?.toInstant()?.toEpochMilli(),
+            infoType = "Stream",
+            uploaderName = extractor.uploaderName,
+            uploaderUrl = uploaderId,
+            uploaderAvatarUrl = extractor.uploaderAvatars.firstOrNull()?.url,
+            uploaderVerified = null,
+            duration = extractor.length,
+            viewCount = extractor.viewCount,
+            textualUploadDate = extractor.textualUploadDate,
+            streamType = null,
+            shortFormContent = false
+        )
+    }
+
+    private fun extractYouTubeUrl(text: String?): String? {
+        if (text.isNullOrBlank()) return null
+        val match = YOUTUBE_URL_REGEX.find(text)?.value ?: return null
+        return match.trimEnd('.', ',', ';', ':', ')', ']', '}', '>')
+    }
+
+    private fun extractVideoId(url: String): String? {
+        val uri = runCatching { Uri.parse(url) }.getOrNull() ?: return null
+        val host = uri.host?.lowercase() ?: return null
+
+        return when {
+            host == "youtu.be" -> uri.pathSegments.firstOrNull()
+            host == "youtube.com" || host == "www.youtube.com" || host == "m.youtube.com" -> {
+                uri.getQueryParameter("v")
+                    ?: uri.pathSegments
+                        .takeIf { it.size >= 2 && it.first() in YOUTUBE_VIDEO_PATHS }
+                        ?.get(1)
+            }
+            else -> null
+        }?.takeIf { it.isNotBlank() }
+    }
+
+    companion object {
+        private val YOUTUBE_URL_REGEX = Regex(
+            "https?://(?:www\\.|m\\.)?(?:youtube\\.com|youtu\\.be)/[^\\s]+",
+            RegexOption.IGNORE_CASE
+        )
+        private val YOUTUBE_VIDEO_PATHS = setOf("shorts", "embed", "live")
     }
 }
-


### PR DESCRIPTION
This PR adds support for opening YouTube links directly in Transpose from other Android apps.

Use case:
A user shares or opens a YouTube link from another app and chooses Transpose. Transpose then resolves the video and starts playback using its existing playback flow.

What this PR adds:
- Support for Android ACTION_SEND with text/plain
- Support for Android ACTION_VIEW for youtube.com and youtu.be links
- Handling for links received when the app is already open via onNewIntent
- Support for common YouTube URL formats:
  - watch?v=
  - youtu.be
  - shorts
  - embed
  - live

The implementation keeps the existing player, repository, and NewPipe-based resolution flow unchanged.

The goal is only to add an external entry point for YouTube links, without changing playback behavior or audio processing.

Example flow:
External app → Share/Open YouTube link → Transpose → video loads → existing pitch controls remain available

I originally suggested this feature by email and prepared this PR as a minimal implementation to make review easier.

Thanks for the great project.